### PR TITLE
fix apply_visitor.

### DIFF
--- a/libs/variant/test/variant.cpp
+++ b/libs/variant/test/variant.cpp
@@ -170,6 +170,18 @@ namespace testspr {
 				TESTSPR_ASSERT(var3.which() == 0);
 				TESTSPR_ASSERT(sprout::get<int>(var3) == 0);
 			}
+			{
+				testspr::x2_visitor<double> visitor1 = {};
+				TESTSPR_BOTH_ASSERT(sprout::apply_visitor(visitor1, var1) == 2.0);
+				TESTSPR_BOTH_ASSERT(sprout::apply_visitor(visitor1, var2) == 0.0);
+			}
+			{
+				auto var3 = var2;
+				testspr::x2_assign_visitor<double> visitor1 = {};
+				TESTSPR_ASSERT(sprout::apply_visitor(visitor1, var3) == 0.0);
+				TESTSPR_ASSERT(var3.which() == 0);
+				TESTSPR_ASSERT(sprout::get<int>(var3) == 0);
+			}
 
 			// operator<<
 			{

--- a/sprout/variant/apply_visitor.hpp
+++ b/sprout/variant/apply_visitor.hpp
@@ -6,7 +6,7 @@
 
 namespace sprout {
 	template<typename Visitor, typename Visitable>
-	inline SPROUT_CONSTEXPR typename Visitor::result_type
+	inline SPROUT_CONSTEXPR typename std::decay<Visitor>::type::result_type
 	apply_visitor(Visitor&& visitor, Visitable&& visitable) {
 		return sprout::forward<Visitable>(visitable).apply_visitor(sprout::forward<Visitor>(visitor));
 	}

--- a/sprout/variant/variant.hpp
+++ b/sprout/variant/variant.hpp
@@ -127,14 +127,14 @@ namespace sprout {
 		template<int I, typename Tuple, typename Visitor>
 		static SPROUT_CONSTEXPR typename std::enable_if<
 			I == sizeof...(Types),
-			typename Visitor::result_type
+			typename std::decay<Visitor>::type::result_type
 		>::type visit(Tuple&& t, Visitor&& v, int which) {
-			return typename Visitor::result_type();
+			return typename std::decay<Visitor>::type::result_type();
 		}
 		template<int I, typename Tuple, typename Visitor>
 		static SPROUT_CONSTEXPR typename std::enable_if<
 			I != sizeof...(Types),
-			typename Visitor::result_type
+			typename std::decay<Visitor>::type::result_type
 		>::type visit(Tuple&& t, Visitor&& v, int which) {
 			return I == which
 				? sprout::forward<Visitor>(v)(sprout::tuples::get<I>(sprout::forward<Tuple>(t)))
@@ -249,11 +249,11 @@ namespace sprout {
 		}
 		// visitation support
 		template<typename Visitor>
-		SPROUT_CONSTEXPR typename Visitor::result_type apply_visitor(Visitor&& visitor) const {
+		SPROUT_CONSTEXPR typename std::decay<Visitor>::type::result_type apply_visitor(Visitor&& visitor) const {
 			return visit<0>(tuple_, sprout::forward<Visitor>(visitor), which_);
 		}
 		template<typename Visitor>
-		typename Visitor::result_type apply_visitor(Visitor&& visitor) {
+		typename std::decay<Visitor>::type::result_type apply_visitor(Visitor&& visitor) {
 			return visit<0>(tuple_, sprout::forward<Visitor>(visitor), which_);
 		}
 	};


### PR DESCRIPTION
apply_visitor に lvalue を渡すとコンパイルエラーになったので修正してみました。
テストは Windows の gcc 4.7.2 と gcc 4.8 で行いました。

``` cpp
struct X{
    typedef int result_type;

    template<typename T>
    constexpr int
    operator ()(T value) const{
        return value;
    }

};

constexpr X x{};
constexpr sprout::variant<int, float> var1{ 42 };
static_assert(sprout::apply_visitor(x, var1) == 42, "");
```
