### PR TITLE
fix adjacent_find typo

### DIFF
--- a/source/libs/sprout/algorithm/adjacent_find.rst
+++ b/source/libs/sprout/algorithm/adjacent_find.rst
@@ -38,7 +38,7 @@ Examples
 Complexity
 ========================================
 
-| For a nonempty range, exactly ``min((i - first) + 1, (last - first) - 1)`` applications of the corresponding predicate, where i is adjacent_findÅfs return value.
+| For a nonempty range, exactly ``min((i - first) + 1, (last - first) - 1)`` applications of the corresponding predicate, where i is adjacent_find's return value.
 | Recursive function invocations in *O(logN)* (logarithmic) depth.
 
 Header


### PR DESCRIPTION
U+2019 was used in adjacent_find's Complexity.
It should be U+0027.
