### PR TITLE
[algorithm.minmax_element] fix minmax_element(max part) etc.

### DIFF
--- a/sprout/algorithm/max_element.hpp
+++ b/sprout/algorithm/max_element.hpp
@@ -18,9 +18,9 @@
 
 namespace sprout {
 	namespace detail {
-		template<typename InputIterator, typename Compare>
-		inline SPROUT_CONSTEXPR InputIterator
-		iter_max(InputIterator a, InputIterator b, Compare comp) {
+		template<typename ForwardIterator, typename Compare>
+		inline SPROUT_CONSTEXPR ForwardIterator
+		iter_max(ForwardIterator a, ForwardIterator b, Compare comp) {
 			return comp(*a, *b) ? b : a;
 		}
 

--- a/sprout/algorithm/minmax_element.hpp
+++ b/sprout/algorithm/minmax_element.hpp
@@ -19,20 +19,20 @@
 
 namespace sprout {
 	namespace detail {
-		template<typename InputIteratorPair, typename Compare>
-		inline SPROUT_CONSTEXPR InputIteratorPair
-		iter_minmax_pair(InputIteratorPair const& a, InputIteratorPair const& b, Compare comp) {
-			return InputIteratorPair(
+		template<typename ForwardIteratorPair, typename Compare>
+		inline SPROUT_CONSTEXPR ForwardIteratorPair
+		iter_minmax_pair(ForwardIteratorPair const& a, ForwardIteratorPair const& b, Compare comp) {
+			return ForwardIteratorPair(
 				comp(*sprout::first(b), *sprout::first(a)) ? sprout::first(b) : sprout::first(a),
-				comp(*sprout::second(a), *sprout::second(b)) ? sprout::second(b) : sprout::second(a)
+				comp(*sprout::second(b), *sprout::second(a)) ? sprout::second(a) : sprout::second(b)
 				);
 		}
-		template<typename InputIteratorPair, typename InputIterator, typename Compare>
-		inline SPROUT_CONSTEXPR InputIteratorPair
-		iter_minmax(InputIteratorPair const& a, InputIterator b, Compare comp) {
-			return InputIteratorPair(
+		template<typename ForwardIteratorPair, typename ForwardIterator, typename Compare>
+		inline SPROUT_CONSTEXPR ForwardIteratorPair
+		iter_minmax(ForwardIteratorPair const& a, ForwardIterator b, Compare comp) {
+			return ForwardIteratorPair(
 				comp(*b, *sprout::first(a)) ? b : sprout::first(a),
-				comp(*sprout::second(a), *b) ? b : sprout::second(a)
+				comp(*sprout::second(b), *a) ? a : sprout::second(b)
 				);
 		}
 


### PR DESCRIPTION
A minmax_element's max part(pair.second) is the **last** iterator to the largest element.

test code here.

``` C++
#include <sprout/algorithm/minmax_element.hpp>
#include <sprout/array.hpp>

SPROUT_STATIC_CONSTEXPR auto input = sprout::make_array<int>(2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 4, 4);
SPROUT_STATIC_CONSTEXPR auto result = sprout::minmax_element(sprout::begin(input), sprout::end(input));
static_assert(*result.first == 1, "a min element is 1.");
static_assert(*result.second == 5, "a max element is 5.");
static_assert(result.first - sprout::begin(input) == 2, "a min element position is 2.");
static_assert(result.second - sprout::begin(input) == 11, "a max element position is 11.");
```

And, rename function template parameter(InputIterator to ForwardIterator).
