### PR TITLE
[algorithm.lexicographical_compare, algorithm.tristate_lexicographical_compare]

### DIFF
--- a/sprout/algorithm/lexicographical_compare.hpp
+++ b/sprout/algorithm/lexicographical_compare.hpp
@@ -11,7 +11,8 @@
 #include <iterator>
 #include <type_traits>
 #include <sprout/config.hpp>
-#include <sprout/iterator/operation.hpp>
+#include <sprout/detail/algorithm/lexicographical_compare.hpp>
+#include <sprout/iterator/distance.hpp>
 #include <sprout/iterator/type_traits/category.hpp>
 #include <sprout/iterator/type_traits/common.hpp>
 #include <sprout/utility/pair/pair.hpp>
@@ -20,55 +21,16 @@
 
 namespace sprout {
 	namespace detail {
-		template<typename InputIterator1, typename InputIterator2, typename Compare>
+		template<typename Difference1, typename Difference2>
 		inline SPROUT_CONSTEXPR bool
 		lexicographical_compare_impl_check(
-			InputIterator1 last1, InputIterator2 last2, Compare comp,
-			sprout::pair<InputIterator1, InputIterator2> const& found
+			Difference1 size1, Difference2 size2,
+			int found
 			)
 		{
-			return found.second == last2 ? false
-				: found.first == last1 || comp(*found.first, *found.second)
-				;
+			return found < 0 || found == 2 && size1 < size2;
 		}
 
-		template<typename RandomAccessIterator1, typename RandomAccessIterator2, typename Compare>
-		inline SPROUT_CONSTEXPR sprout::pair<RandomAccessIterator1, RandomAccessIterator2>
-		lexicographical_compare_impl_ra_1(
-			RandomAccessIterator1 first1, RandomAccessIterator1 last1, RandomAccessIterator2 first2, RandomAccessIterator2 last2, Compare comp,
-			typename std::iterator_traits<RandomAccessIterator1>::difference_type pivot, sprout::pair<RandomAccessIterator1, RandomAccessIterator2> const& found
-			)
-		{
-			typedef sprout::pair<RandomAccessIterator1, RandomAccessIterator2> found_type;
-			return found.first != first1 ? found
-				: pivot == 0 ? (comp(*first1, *first2) || comp(*first2, *first1) ? found_type(first1, first2) : found_type(last1, last2))
-				: sprout::detail::lexicographical_compare_impl_ra_1(
-					sprout::next(first1, pivot), last1, sprout::next(first2, pivot), last2, comp,
-					(sprout::distance(first1, last1) - pivot) / 2,
-					sprout::detail::lexicographical_compare_impl_ra_1(
-						first1, sprout::next(first1, pivot), first2, sprout::next(first2, pivot), comp,
-						pivot / 2,
-						found_type(first1, first2)
-						)
-					)
-				;
-		}
-		template<typename RandomAccessIterator1, typename RandomAccessIterator2, typename Compare>
-		inline SPROUT_CONSTEXPR bool
-		lexicographical_compare_impl_ra(
-			RandomAccessIterator1 first1, RandomAccessIterator1 last1, RandomAccessIterator2 first2, RandomAccessIterator2 last2, Compare comp,
-			typename std::iterator_traits<RandomAccessIterator1>::difference_type size
-			)
-		{
-			typedef sprout::pair<RandomAccessIterator1, RandomAccessIterator2> found_type;
-			return sprout::detail::lexicographical_compare_impl_check(
-				last1, last2, comp,
-				sprout::detail::lexicographical_compare_impl_ra_1(
-					first1, sprout::next(first1, size), first2, sprout::next(first2, size), comp,
-					size / 2, found_type(first1, first2)
-					)
-				);
-		}
 		template<typename RandomAccessIterator1, typename RandomAccessIterator2, typename Compare>
 		inline SPROUT_CONSTEXPR typename std::enable_if<
 			sprout::is_constant_distance_iterator<RandomAccessIterator1>::value,
@@ -81,53 +43,29 @@ namespace sprout {
 		{
 			return first2 == last2 ? false
 				: first1 == last1 ? true
-				: sprout::detail::lexicographical_compare_impl_ra(
-					first1, last1, first2, last2, comp,
-					NS_SSCRISK_CEL_OR_SPROUT::min(sprout::distance(first1, last1), sprout::distance(first2, last2))
+				: sprout::detail::lexicographical_compare_impl_check(
+					sprout::distance(first1, last1), sprout::distance(first2, last2),
+					sprout::detail::lexicographical_compare_impl_ra(
+						first1, first2, comp,
+						NS_SSCRISK_CEL_OR_SPROUT::min(sprout::distance(first1, last1), sprout::distance(first2, last2)),
+						2
+						)
 					)
 				;
 		}
 
 		template<typename InputIterator1, typename InputIterator2, typename Compare>
-		inline SPROUT_CONSTEXPR sprout::pair<InputIterator1, InputIterator2>
-		lexicographical_compare_impl_1(
-			sprout::pair<InputIterator1, InputIterator2> current,
+		inline SPROUT_CONSTEXPR bool
+		lexicographical_compare_impl_check(
 			InputIterator1 last1, InputIterator2 last2, Compare comp,
-			typename std::iterator_traits<InputIterator1>::difference_type n
+			sprout::pair<InputIterator1, InputIterator2> const& found
 			)
 		{
-			typedef sprout::pair<InputIterator1, InputIterator2> type;
-			return current.second == last2 || current.first == last1 ? current
-				: n == 1 ? comp(*current.first, *current.second) ? type(last1, current.second)
-					: comp(*current.second, *current.first) ? type(current.first, last2)
-					: type(sprout::next(current.first), sprout::next(current.second))
-				: sprout::detail::lexicographical_compare_impl_1(
-					sprout::detail::lexicographical_compare_impl_1(
-						current,
-						last1, last2, comp, n / 2
-						),
-					last1, last2, comp, n - n / 2
-					)
+			return found.second == last2 ? false
+				: found.first == last1 || comp(*found.first, *found.second)
 				;
 		}
-		template<typename InputIterator1, typename InputIterator2, typename Compare>
-		inline SPROUT_CONSTEXPR sprout::pair<InputIterator1, InputIterator2>
-		lexicographical_compare_impl(
-			sprout::pair<InputIterator1, InputIterator2> current,
-			InputIterator1 last1, InputIterator2 last2, Compare comp,
-			typename std::iterator_traits<InputIterator1>::difference_type n
-			)
-		{
-			return current.second == last2 || current.first == last1 ? current
-				: sprout::detail::lexicographical_compare_impl(
-					sprout::detail::lexicographical_compare_impl_1(
-						current,
-						last1, last2, comp, n
-						),
-					last1, last2, comp, n * 2
-					)
-				;
-		}
+
 		template<typename InputIterator1, typename InputIterator2, typename Compare>
 		inline SPROUT_CONSTEXPR bool
 		lexicographical_compare(

--- a/sprout/detail/algorithm/lexicographical_compare.hpp
+++ b/sprout/detail/algorithm/lexicographical_compare.hpp
@@ -1,0 +1,73 @@
+#ifndef SPROUT_DETAIL_ALGORITHM_LEXICOGRAPHICAL_COMPARE_HPP
+#define SPROUT_DETAIL_ALGORITHM_LEXICOGRAPHICAL_COMPARE_HPP
+
+#include <sprout/config.hpp>
+#include <sprout/utility/pair/pair.hpp>
+#include <sprout/iterator/next.hpp>
+
+namespace sprout {
+	namespace detail {
+		template<typename RandomAccessIterator1, typename RandomAccessIterator2, typename Compare>
+		inline SPROUT_CONSTEXPR int
+		lexicographical_compare_impl_ra(
+			RandomAccessIterator1 first1, RandomAccessIterator2 first2, Compare comp,
+			typename std::iterator_traits<RandomAccessIterator1>::difference_type size,
+			int found
+			)
+		{
+			return found != 2 ? found
+				: size == 1 ? comp(*first1, *first2) ? -1 : comp(*first2, *first1) ? 1 : 2
+				: sprout::detail::lexicographical_compare_impl_ra(
+					sprout::next(first1, size / 2), sprout::next(first2, size / 2), comp, size - size / 2,
+					sprout::detail::lexicographical_compare_impl_ra(
+						first1, first2, comp, size / 2,
+						2
+						)
+					)
+				;
+		}
+
+		template<typename InputIterator1, typename InputIterator2, typename Compare>
+		inline SPROUT_CONSTEXPR sprout::pair<InputIterator1, InputIterator2>
+		lexicographical_compare_impl_1(
+			sprout::pair<InputIterator1, InputIterator2> const& current,
+			InputIterator1 last1, InputIterator2 last2, Compare comp,
+			typename std::iterator_traits<InputIterator1>::difference_type n
+			)
+		{
+			typedef sprout::pair<InputIterator1, InputIterator2> type;
+			return current.second == last2 || current.first == last1 ? current
+				: n == 1 ? comp(*current.first, *current.second) ? type(last1, current.second)
+					: comp(*current.second, *current.first) ? type(current.first, last2)
+					: type(sprout::next(current.first), sprout::next(current.second))
+				: sprout::detail::lexicographical_compare_impl_1(
+					sprout::detail::lexicographical_compare_impl_1(
+						current,
+						last1, last2, comp, n / 2
+						),
+					last1, last2, comp, n - n / 2
+					)
+				;
+		}
+		template<typename InputIterator1, typename InputIterator2, typename Compare>
+		inline SPROUT_CONSTEXPR sprout::pair<InputIterator1, InputIterator2>
+		lexicographical_compare_impl(
+			sprout::pair<InputIterator1, InputIterator2> const& current,
+			InputIterator1 last1, InputIterator2 last2, Compare comp,
+			typename std::iterator_traits<InputIterator1>::difference_type n
+			)
+		{
+			return current.second == last2 || current.first == last1 ? current
+				: sprout::detail::lexicographical_compare_impl(
+					sprout::detail::lexicographical_compare_impl_1(
+						current,
+						last1, last2, comp, n
+						),
+					last1, last2, comp, n * 2
+					)
+				;
+		}
+	}	// namespace detail
+}	// namespace sprout
+
+#endif /* #ifndef SPROUT_DETAIL_ALGORITHM_LEXICOGRAPHICAL_COMPARE_HPP */


### PR DESCRIPTION
Fix tristate_lexicographical_compare InputIterator version (wrong version was called).
Reduce compare function application for RandomAccessIterator verion.
Move some common functions to new header file.
