### PR TITLE
fix math::is_odd for a negative argument

### DIFF
--- a/sprout/math/is_odd.hpp
+++ b/sprout/math/is_odd.hpp
@@ -33,7 +33,7 @@ namespace sprout {
 		inline SPROUT_CONSTEXPR bool
 		is_odd(FloatType x) {
 			return sprout::math::isfinite(x)
-				&& sprout::math::detail::is_odd_unchecked(x)
+				&& sprout::math::detail::is_odd_unchecked(x < 0 ? -x : x)
 				;
 		}
 	}	// namespace math


### PR DESCRIPTION
I think that sprout::math::is_odd(-1) should be true.

It also fixes math::pow for a case that x is a negative and y is a negative odd integer.

cf. http://melpon.org/wandbox/permlink/XVKea2I6CdVJCbZX
