### PR TITLE
fix numeric_limits<long double>

### DIFF
--- a/sprout/limits.hpp
+++ b/sprout/limits.hpp
@@ -293,7 +293,7 @@ namespace sprout {
 		long double,
 		LDBL_MIN, LDBL_MAX,
 		LDBL_EPSILON, 0.5L,
-		__builtin_huge_val(), __builtin_nan(""), __builtin_nans(""), __LDBL_DENORM_MIN__
+		__builtin_huge_vall(), __builtin_nanl(""), __builtin_nansl(""), __LDBL_DENORM_MIN__
 		);
 #endif	// #if !defined(__LDBL_DENORM_MIN__)
 #undef SPROUT_NUMERIC_LIMITS_FLOATING_POINT_SPECIALIZED_DECL


### PR DESCRIPTION
If SPROUT_NO_CXX11_NUMERIC_LIMITS and **LDBL_DENORM_MIN** is defined,
the definition of numeric_limits uses __builtin_huge_val, __builtin_nan
and __builtin_nans but I think that it should use __builtin_huge_vall,
__builtin_nanl and __builtin_nansl, respectively.
