### PR TITLE
fix find_symmetric_difference

### DIFF
--- a/sprout/algorithm/find_symmetric_difference.hpp
+++ b/sprout/algorithm/find_symmetric_difference.hpp
@@ -55,7 +55,7 @@ namespace sprout {
 			InputIterator1 last1, InputIterator2 last2, Compare comp, typename std::iterator_traits<InputIterator1>::difference_type n
 			)
 		{
-			return sprout::tuples::get<2>(current) || sprout::tuples::get<0>(current) == last1 ? current
+			return sprout::tuples::get<2>(current) || sprout::tuples::get<0>(current) == last1 || sprout::tuples::get<1>(current) == last2 ? current
 				: sprout::detail::find_symmetric_difference_impl(
 					sprout::detail::find_symmetric_difference_impl_1(
 						current,


### PR DESCRIPTION
If distance(first1, lat1) > distance(first2, last2), the find_symmetric_difference
caused an infinite loop.

cf. http://melpon.org/wandbox/permlink/Ca87oxrYGg6gAugj