### PR TITLE
Allows tests to be skipped

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,11 @@ include (FindPkgConfig)
 include(CheckCXXSourceCompiles)
 
 # build type
-set(CMAKE_BUILD_TYPE Debug)
+if( NOT DEFINED CMAKE_BUILD_TYPE )
+  set(CMAKE_BUILD_TYPE Debug)
+endif( NOT DEFINED CMAKE_BUILD_TYPE )
+
+option( BUILD_TESTS "If true Sprout's tests will be built" TRUE)
 
 
 set(CMAKE_CXX_FLAGS_DEBUG "-W -Wall -Wextra -Wno-unused-parameter -Werror -std=c++0x -O0 -g")
@@ -21,6 +25,7 @@ set(CMAKE_C_FLAGS_RELEASE "-W -Wall -Wextra -Wno-unused-parameter -Werror -O2")
 if( NOT DEFINED CMAKE_VERBOSE_MAKEFILE )
   set(CMAKE_VERBOSE_MAKEFILE OFF)
 endif( NOT DEFINED CMAKE_VERBOSE_MAKEFILE )
+
 
 if( NOT DEFINED Boost_USE_MULTITHREADED )
   set(Boost_USE_MULTITHREADED ON)
@@ -35,5 +40,8 @@ pkg_check_modules(OpenCV opencv)
 
 INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS} )
 link_directories( ${Boost_LIBRARY_DIRS} )
-subdirs( sprout libs tools cmake )
+subdirs( sprout  tools cmake )
+if( ${BUILD_TESTS} )
+  subdirs(libs)
+endif( ${BUILD_TESTS} )
 


### PR DESCRIPTION
This PR introduces two minor changes to the CMake build infrastructure in order to facilitate including Sprout in another CMake project via CMake's external project API.

The first change ensures `CMAKE_BUILD_TYPE` is only set if it is not already set.  Previously it was always being set to `Debug`.

The second change introduces a variable `BUILD_TESTS`  which controls whether or not the tests are built.  From the perspective of the top-level CMake project (*i.e.* the one including Sprout via CMake's external project API), having to build the tests significantly increases the compile time.  I have introduced `BUILD_TESTS` so that it defaults to true, thus providing a build analogous to before `BUILD_TESTS` introduction.

Both of these changes should be transparent to other Sprout users.