### PR TITLE
Fix wrong header guard being used

### DIFF
--- a/sprout/range/algorithm/any_of_equal.hpp
+++ b/sprout/range/algorithm/any_of_equal.hpp
@@ -5,8 +5,8 @@
   Distributed under the Boost Software License, Version 1.0. (See accompanying
   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
-#ifndef SPROUT_RANGE_ALGORITHM_ALL_OF_EQUAL_HPP
-#define SPROUT_RANGE_ALGORITHM_ALL_OF_EQUAL_HPP
+#ifndef SPROUT_RANGE_ALGORITHM_ANY_OF_EQUAL_HPP
+#define SPROUT_RANGE_ALGORITHM_ANY_OF_EQUAL_HPP
 
 #include <sprout/config.hpp>
 #include <sprout/container/functions.hpp>
@@ -25,4 +25,4 @@ namespace sprout {
 	}	// namespace range
 }	// namespace sprout
 
-#endif	// #ifndef SPROUT_RANGE_ALGORITHM_ALL_OF_EQUAL_HPP
+#endif	// #ifndef SPROUT_RANGE_ALGORITHM_ANY_OF_EQUAL_HPP


### PR DESCRIPTION
The header guard for this file should be SPROUT_RANGE_ALGORITHM_ANY_OF_EQUAL_HPP, not SPROUT_RANGE_ALGORITHM_ALL_OF_EQUAL_HPP. If /range/algorithm/all_of_equal.hpp is included then sprout::range::any_of_equal will not be available for use after.